### PR TITLE
Fix authentication display consistency across admin pages

### DIFF
--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -24,6 +24,7 @@ import {
   useExportMembers,
 } from "@/features/members/hooks";
 import { useRequireAdmin } from "@/hooks/use-require-auth";
+import { mapUserForLayout } from "@/lib/auth-utils";
 import { Users, UserCheck, UserX, Clock, Download } from "lucide-react";
 import { useRouter } from "next/navigation";
 
@@ -34,8 +35,11 @@ export default function MembersPage() {
   const router = useRouter();
 
   // Require admin role for entire page
-  const { isLoading: isAuthLoading, hasRequiredRole } =
-    useRequireAdmin("/login");
+  const {
+    user,
+    isLoading: isAuthLoading,
+    hasRequiredRole,
+  } = useRequireAdmin("/login");
 
   // Simplified filter state management
   const { filters, updateFilters, databaseFilters } = useSimpleMemberFilters();
@@ -68,7 +72,7 @@ export default function MembersPage() {
 
   if (isAuthLoading) {
     return (
-      <MainLayout>
+      <MainLayout user={mapUserForLayout(user)}>
         <div className="flex min-h-[400px] items-center justify-center">
           <div className="border-primary h-8 w-8 animate-spin rounded-full border-b-2"></div>
         </div>
@@ -107,8 +111,11 @@ export default function MembersPage() {
     // The cache invalidation in EditMemberDialog should handle this automatically
   };
 
+  // Convert user object to expected format for MainLayout
+  const layoutUser = mapUserForLayout(user);
+
   return (
-    <MainLayout>
+    <MainLayout user={layoutUser}>
       <div className="space-y-6">
         {/* Header Section */}
         <div className="flex items-center justify-between">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,7 @@ import {
   Activity,
 } from "lucide-react";
 import { useRequireAdmin } from "@/hooks/use-require-auth";
+import { mapUserForLayout } from "@/lib/auth-utils";
 import { LoadingSkeleton } from "@/components/ui/loading-skeleton";
 import { MemberEvolutionChart } from "@/features/dashboard/components/member-evolution-chart";
 import { MemberStatusDistributionChart } from "@/features/dashboard/components/member-status-distribution-chart";
@@ -40,22 +41,7 @@ export default function Home() {
   }
 
   // Convert user object to expected format for MainLayout
-  const layoutUser = {
-    name:
-      user.first_name && user.last_name
-        ? `${user.first_name} ${user.last_name}`
-        : (user.email as string) || "Unknown User",
-    email: (user.email as string) || "",
-    avatar:
-      (user.avatar_url as string) ||
-      (user.first_name && typeof user.first_name === "string"
-        ? user.first_name[0]
-        : "") ||
-      (user.email && typeof user.email === "string"
-        ? (user.email as string)[0]
-        : "") ||
-      "A",
-  };
+  const layoutUser = mapUserForLayout(user);
 
   // Stats data
   const stats = [

--- a/src/app/trainers/page.tsx
+++ b/src/app/trainers/page.tsx
@@ -21,6 +21,7 @@ import {
   useTrainersWithExpiringCerts,
 } from "@/features/trainers/hooks";
 import { useRequireAdmin } from "@/hooks/use-require-auth";
+import { mapUserForLayout } from "@/lib/auth-utils";
 import { UserCheck, Users, Award, Calendar, Download } from "lucide-react";
 import { useRouter } from "next/navigation";
 
@@ -32,8 +33,11 @@ export default function TrainersPage() {
   const router = useRouter();
 
   // Require admin role for entire page
-  const { isLoading: isAuthLoading, hasRequiredRole } =
-    useRequireAdmin("/login");
+  const {
+    user,
+    isLoading: isAuthLoading,
+    hasRequiredRole,
+  } = useRequireAdmin("/login");
 
   // Simplified filter state management
   const { filters, updateFilters, databaseFilters } = useSimpleTrainerFilters();
@@ -58,7 +62,7 @@ export default function TrainersPage() {
 
   if (isAuthLoading) {
     return (
-      <MainLayout>
+      <MainLayout user={mapUserForLayout(user)}>
         <div className="flex min-h-[400px] items-center justify-center">
           <div className="border-primary h-8 w-8 animate-spin rounded-full border-b-2"></div>
         </div>
@@ -119,8 +123,11 @@ export default function TrainersPage() {
     await exportTrainers(trainers || []);
   };
 
+  // Convert user object to expected format for MainLayout
+  const layoutUser = mapUserForLayout(user);
+
   return (
-    <MainLayout>
+    <MainLayout user={layoutUser}>
       <div className="space-y-6">
         {/* Header Section */}
         <div className="flex items-center justify-between">

--- a/src/lib/__tests__/auth-utils.test.ts
+++ b/src/lib/__tests__/auth-utils.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { mapUserForLayout } from "../auth-utils";
+
+describe("mapUserForLayout", () => {
+  it("should return undefined for null user", () => {
+    const result = mapUserForLayout(null);
+    expect(result).toBeUndefined();
+  });
+
+  it("should map user with first_name and last_name", () => {
+    const user = {
+      first_name: "John",
+      last_name: "Doe",
+      email: "john@example.com",
+      avatar_url: "https://example.com/avatar.jpg",
+    };
+
+    const result = mapUserForLayout(user);
+    expect(result).toEqual({
+      name: "John Doe",
+      email: "john@example.com",
+      avatar: "https://example.com/avatar.jpg",
+    });
+  });
+
+  it("should use email as name when no first/last name", () => {
+    const user = {
+      email: "john@example.com",
+    };
+
+    const result = mapUserForLayout(user);
+    expect(result).toEqual({
+      name: "john@example.com",
+      email: "john@example.com",
+      avatar: "j",
+    });
+  });
+
+  it("should use first letter of first_name as avatar when no avatar_url", () => {
+    const user = {
+      first_name: "John",
+      last_name: "Doe",
+      email: "john@example.com",
+    };
+
+    const result = mapUserForLayout(user);
+    expect(result).toEqual({
+      name: "John Doe",
+      email: "john@example.com",
+      avatar: "J",
+    });
+  });
+
+  it("should use first letter of email as avatar when no other options", () => {
+    const user = {
+      email: "john@example.com",
+    };
+
+    const result = mapUserForLayout(user);
+    expect(result).toEqual({
+      name: "john@example.com",
+      email: "john@example.com",
+      avatar: "j",
+    });
+  });
+
+  it("should use 'A' as fallback avatar", () => {
+    const user = {};
+
+    const result = mapUserForLayout(user);
+    expect(result).toEqual({
+      name: "Unknown User",
+      email: "",
+      avatar: "A",
+    });
+  });
+
+  it("should handle undefined/null properties gracefully", () => {
+    const user = {
+      first_name: undefined,
+      last_name: null,
+      email: undefined,
+      avatar_url: null,
+    };
+
+    const result = mapUserForLayout(user);
+    expect(result).toEqual({
+      name: "Unknown User",
+      email: "",
+      avatar: "A",
+    });
+  });
+});

--- a/src/lib/auth-utils.ts
+++ b/src/lib/auth-utils.ts
@@ -1,0 +1,37 @@
+/**
+ * User interface expected by MainLayout component
+ */
+export interface LayoutUser {
+  name: string;
+  email: string;
+  avatar?: string;
+}
+
+/**
+ * Converts a user object to the format expected by MainLayout
+ * Extracts user data and maps it to { name, email, avatar } format
+ */
+export function mapUserForLayout(
+  user: Record<string, unknown> | null
+): LayoutUser | undefined {
+  if (!user) {
+    return undefined;
+  }
+
+  return {
+    name:
+      user.first_name && user.last_name
+        ? `${user.first_name} ${user.last_name}`
+        : (user.email as string) || "Unknown User",
+    email: (user.email as string) || "",
+    avatar:
+      (user.avatar_url as string) ||
+      (user.first_name && typeof user.first_name === "string"
+        ? user.first_name[0]
+        : "") ||
+      (user.email && typeof user.email === "string"
+        ? (user.email as string)[0]
+        : "") ||
+      "A",
+  };
+}


### PR DESCRIPTION
- Create reusable auth utility in src/lib/auth-utils.ts
- Fix Members and Trainers pages to display session timer correctly
- Refactor Dashboard to use shared user mapping logic
- Add comprehensive tests for auth utility functions

Previously, session timer showed on Dashboard but disappeared on Members/Trainers pages, showing "Sign In" instead. Now all admin pages consistently display user authentication status.

🤖 Generated with [Claude Code](https://claude.ai/code)